### PR TITLE
feat(admin,web): add pull request preview

### DIFF
--- a/.github/workflows/admin-preview.yml
+++ b/.github/workflows/admin-preview.yml
@@ -18,9 +18,9 @@ on:
       - .github/workflows/admin-preview.yml
   
 jobs:
-  Admin-Build:
+  build:
+    name: Admin Build and Lint
     runs-on: ubuntu-latest
-    timeout-minutes: 15
     steps:
       - name: Check out code
         uses: actions/checkout@v3
@@ -46,7 +46,7 @@ jobs:
         run : turbo lint
 
   Admin-Deploy-Preview:
-    needs: Admin-Build
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -63,7 +63,7 @@ jobs:
       - name: Deploy Project Artifacts to Vercel
         run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} > admin_deployment_url.txt
 
-      - name: Read Admin Preview URL from file
+      - name: Read web URL from file
         id: read-url
         run: |
           url=$(cat admin_deployment_url.txt)

--- a/.github/workflows/admin-preview.yml
+++ b/.github/workflows/admin-preview.yml
@@ -5,21 +5,18 @@ env:
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_ADMIN_PROJECT_ID }}
 
 on:
-  push:
-    branches:
-      - '**'
+  pull_request:
+    types: [opened, synchronize]
     paths:
       - apps/admin/**
       - packages/**
       - .npmrc
       - .nvmrc
-      - .eslintrc.js
       - "*.config.js"
       - .github/workflows/admin-preview.yml
-  
+
 jobs:
-  build:
-    name: Admin Build and Lint
+  Admin-Build:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -46,7 +43,7 @@ jobs:
         run : turbo lint
 
   Admin-Deploy-Preview:
-    needs: build
+    needs: Admin-Build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/admin-preview.yml
+++ b/.github/workflows/admin-preview.yml
@@ -6,20 +6,19 @@ env:
 
 on:
   push:
-    branches: ["main"]
-  pull_request:
-    types: [opened, synchronize]
+    branches:
+      - '**'
     paths:
       - apps/admin/**
       - packages/**
       - .npmrc
       - .nvmrc
+      - .eslintrc.js
       - "*.config.js"
       - .github/workflows/admin-preview.yml
-
+  
 jobs:
-  build:
-    name: Build and Lint
+  Admin-Build:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -46,8 +45,8 @@ jobs:
       - name: Lint
         run : turbo lint
 
-  Deploy-Admin-Preview:
-    needs: build
+  Admin-Deploy-Preview:
+    needs: Admin-Build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -64,7 +63,7 @@ jobs:
       - name: Deploy Project Artifacts to Vercel
         run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} > admin_deployment_url.txt
 
-      - name: Read web URL from file
+      - name: Read Admin Preview URL from file
         id: read-url
         run: |
           url=$(cat admin_deployment_url.txt)

--- a/.github/workflows/admin-preview.yml
+++ b/.github/workflows/admin-preview.yml
@@ -74,9 +74,9 @@ jobs:
         uses: actions/github-script@v6
         if: ${{ success() }}
         env:
-          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN_PR_COMMENT }}
         with:
-          github-token: ${{ secrets.ACCESS_TOKEN }}
+          github-token: ${{ secrets.ACCESS_TOKEN_PR_COMMENT }}
           script: |
             const prNumber = context.payload.pull_request.number;
             const url = "${{ steps.read-url.outputs.PREVIEW_URL }}";

--- a/.github/workflows/admin-preview.yml
+++ b/.github/workflows/admin-preview.yml
@@ -1,0 +1,90 @@
+name: Admin test workflow
+
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_ADMIN_PROJECT_ID }}
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - apps/admin/**
+      - packages/**
+      - .npmrc
+      - .nvmrc
+      - "*.config.js"
+      - .github/workflows/admin-preview.yml
+
+jobs:
+  build:
+    name: Build and Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'yarn'
+
+      - name: Install Turbo CLI
+        run: npm install --global turbo@latest
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Build
+        run: turbo build --filter=ui --filter=admin
+
+      - name: Lint
+        run : turbo lint
+
+  Deploy-Admin-Preview:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+    
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+      
+      - name: Pull Vercel Environment Information
+        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build Project Artifacts
+        run:  vercel build --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy Project Artifacts to Vercel
+        run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} > admin_deployment_url.txt
+
+      - name: Read web URL from file
+        id: read-url
+        run: |
+          url=$(cat admin_deployment_url.txt)
+          echo "PREVIEW_URL=${url}" >> $GITHUB_OUTPUT
+
+      - name: Create Pull Request Comment
+        uses: actions/github-script@v6
+        if: ${{ success() }}
+        env:
+          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+        with:
+          github-token: ${{ secrets.ACCESS_TOKEN }}
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const url = "${{ steps.read-url.outputs.PREVIEW_URL }}";
+            const { data: comment } = await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: `Admin Preview: ${url}`,
+            });
+            console.log(`Comment created: ${comment.html_url}`);
+ 

--- a/.github/workflows/admin-preview.yml
+++ b/.github/workflows/admin-preview.yml
@@ -1,4 +1,4 @@
-name: Admin test workflow
+name: Admin preview workflow
 
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}

--- a/.github/workflows/admin-preview.yml
+++ b/.github/workflows/admin-preview.yml
@@ -8,8 +8,8 @@ on:
   pull_request:
     types: [opened, synchronize]
     paths:
-      - apps/admin/**
-      - packages/**
+      - "apps/admin/**"
+      - "packages/**"
       - .npmrc
       - .nvmrc
       - "*.config.js"

--- a/.github/workflows/web-preview.yml
+++ b/.github/workflows/web-preview.yml
@@ -1,4 +1,4 @@
-name: Web test workflow
+name: Web preview workflow
 
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}

--- a/.github/workflows/web-preview.yml
+++ b/.github/workflows/web-preview.yml
@@ -8,8 +8,8 @@ on:
   pull_request:
     types: [opened, synchronize]
     paths:
-      - apps/web/**
-      - packages/**
+      - "apps/web/**"
+      - "packages/**"
       - .npmrc
       - .nvmrc
       - "*.config.js"

--- a/.github/workflows/web-preview.yml
+++ b/.github/workflows/web-preview.yml
@@ -1,0 +1,91 @@
+name: Web test workflow
+
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_WEB_PROJECT_ID }}
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - apps/web/**
+      - packages/**
+      - .npmrc
+      - .nvmrc
+      - "*.config.js"
+      - .github/workflows/web-preview.yml
+ 
+
+jobs:
+  build:
+    name: Build and Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'yarn'
+
+      - name: Install Turbo CLI
+        run: npm install --global turbo@latest
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Build
+        run: turbo build --filter=ui --filter=web
+
+      - name: Lint
+        run : turbo lint
+
+  Deploy-Web-Preview:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+    
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+      
+      - name: Pull Vercel Environment Information
+        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build Project Artifacts
+        run:  vercel build --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy Project Artifacts to Vercel
+        run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} > web_deployment_url.txt
+
+      - name: Read web URL from file
+        id: read-url
+        run: |
+          url=$(cat web_deployment_url.txt)
+          echo "PREVIEW_URL=${url}" >> $GITHUB_OUTPUT
+
+      - name: Create Pull Request Comment
+        uses: actions/github-script@v6
+        if: ${{ success() }}
+        env:
+          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN_PR_COMMENT }}
+        with:
+          github-token: ${{ secrets.ACCESS_TOKEN_PR_COMMENT }}
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const url = "${{ steps.read-url.outputs.PREVIEW_URL }}";
+            const { data: comment } = await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: `Web Preview: ${url}`,
+            });
+            console.log(`Comment created: ${comment.html_url}`);
+ 

--- a/.github/workflows/web-preview.yml
+++ b/.github/workflows/web-preview.yml
@@ -5,22 +5,18 @@ env:
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_WEB_PROJECT_ID }}
 
 on:
-  push:
-    branches:
-      - '**'
+  pull_request:
+    types: [opened, synchronize]
     paths:
       - apps/web/**
       - packages/**
       - .npmrc
       - .nvmrc
-      - .eslintrc.js
       - "*.config.js"
       - .github/workflows/web-preview.yml
  
-
 jobs:
-  build:
-    name: Web Build and Lint
+  Web-Build:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -47,7 +43,7 @@ jobs:
         run : turbo lint
 
   Deploy-Web-Preview:
-    needs: build
+    needs: Web-Build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/web-preview.yml
+++ b/.github/workflows/web-preview.yml
@@ -6,20 +6,20 @@ env:
 
 on:
   push:
-    branches: ["main"]
-  pull_request:
-    types: [opened, synchronize]
+    branches:
+      - '**'
     paths:
       - apps/web/**
       - packages/**
       - .npmrc
       - .nvmrc
+      - .eslintrc.js
       - "*.config.js"
       - .github/workflows/web-preview.yml
  
 
 jobs:
-  build:
+  Web-Build:
     name: Build and Lint
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -47,8 +47,8 @@ jobs:
       - name: Lint
         run : turbo lint
 
-  Deploy-Web-Preview:
-    needs: build
+  Web-Deploy-Preview:
+    needs: Web-Build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -65,7 +65,7 @@ jobs:
       - name: Deploy Project Artifacts to Vercel
         run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} > web_deployment_url.txt
 
-      - name: Read web URL from file
+      - name: Read Web Preview URL from file
         id: read-url
         run: |
           url=$(cat web_deployment_url.txt)

--- a/.github/workflows/web-preview.yml
+++ b/.github/workflows/web-preview.yml
@@ -19,10 +19,9 @@ on:
  
 
 jobs:
-  Web-Build:
-    name: Build and Lint
+  build:
+    name: Web Build and Lint
     runs-on: ubuntu-latest
-    timeout-minutes: 15
     steps:
       - name: Check out code
         uses: actions/checkout@v3
@@ -47,8 +46,8 @@ jobs:
       - name: Lint
         run : turbo lint
 
-  Web-Deploy-Preview:
-    needs: Web-Build
+  Deploy-Web-Preview:
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -65,7 +64,7 @@ jobs:
       - name: Deploy Project Artifacts to Vercel
         run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} > web_deployment_url.txt
 
-      - name: Read Web Preview URL from file
+      - name: Read web URL from file
         id: read-url
         run: |
           url=$(cat web_deployment_url.txt)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Handpoen-web
+# Handpeon-web
 
 ![HTML5](https://img.shields.io/static/v1?style=for-the-badge&message=HTML5&color=E34F26&logo=HTML5&logoColor=FFFFFF&label=) ![CSS3](https://img.shields.io/static/v1?style=for-the-badge&message=CSS3&color=1572B6&logo=CSS3&logoColor=FFFFFF&label=) ![Tailwind CSS](https://img.shields.io/static/v1?style=for-the-badge&message=Tailwind+CSS&color=222222&logo=Tailwind+CSS&logoColor=06B6D4&label=) ![TypeScript](https://img.shields.io/static/v1?style=for-the-badge&message=TypeScript&color=3178C6&logo=TypeScript&logoColor=FFFFFF&label=) ![React](https://img.shields.io/static/v1?style=for-the-badge&message=React&color=222222&logo=React&logoColor=61DAFB&label=) ![Next.js](https://img.shields.io/static/v1?style=for-the-badge&message=Next.js&color=000000&logo=Next.js&logoColor=FFFFFF&label=) ![Turborepo](https://img.shields.io/static/v1?style=for-the-badge&message=Turborepo&color=EF4444&logo=Turborepo&logoColor=FFFFFF&label=) ![Vercel](https://img.shields.io/static/v1?style=for-the-badge&message=Vercel&color=000000&logo=Vercel&logoColor=FFFFFF&label=) ![GitHub](https://img.shields.io/static/v1?style=for-the-badge&message=GitHub&color=181717&logo=GitHub&logoColor=FFFFFF&label=) ![GitHub Actions](https://img.shields.io/static/v1?style=for-the-badge&message=GitHub+Actions&color=2088FF&logo=GitHub+Actions&logoColor=FFFFFF&label=)
 
@@ -14,8 +14,8 @@
 ## How to start
 
 ```shell
-git clone https://github.com/HAND-PEON/handpoen-web.git
-cd handpoen-web
+git clone https://github.com/HAND-PEON/handpeon-web.git
+cd handpeon-web
 
 yarn install
 turbo build

--- a/apps/admin/src/app/page.tsx
+++ b/apps/admin/src/app/page.tsx
@@ -9,6 +9,7 @@ export default function Home() {
         <Button />
         <div className="brandblue ui-brandblue bg-brandblue">
           tttttttttttttttttttttttttttttteeeeeeeeeeeeeeeeeeeeeeeesssssssssstttttttt
+          어드민 테스트 문구 입니다.
         </div>
       </div>
       <div className="z-10 w-full max-w-5xl items-center justify-between font-mono text-sm lg:flex">

--- a/apps/admin/vercel.json
+++ b/apps/admin/vercel.json
@@ -1,0 +1,3 @@
+{
+  "buildCommand": "turbo build --filter=ui --filter=admin"
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -4,7 +4,7 @@ export default function Home() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-between p-24">
       <div className="z-10 w-full max-w-5xl items-center justify-between font-mono text-sm lg:flex">
-        <div>web 페이지 입니다.</div>
+        <div>web 페이지 입니다!!!</div>
         <p className="fixed left-0 top-0 flex w-full justify-center border-b border-gray-300 bg-gradient-to-b from-zinc-200 pb-6 pt-8 backdrop-blur-2xl dark:border-neutral-800 dark:bg-zinc-800/30 dark:from-inherit lg:static lg:w-auto  lg:rounded-xl lg:border lg:bg-gray-200 lg:p-4 lg:dark:bg-zinc-800/30">
           Get started by editing&nbsp;
           <code className="font-mono font-bold">src/app/page.tsx</code>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,9 +1,10 @@
-import Image from 'next/image'
+import Image from "next/image";
 
 export default function Home() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-between p-24">
       <div className="z-10 w-full max-w-5xl items-center justify-between font-mono text-sm lg:flex">
+        <div>web 페이지 입니다.</div>
         <p className="fixed left-0 top-0 flex w-full justify-center border-b border-gray-300 bg-gradient-to-b from-zinc-200 pb-6 pt-8 backdrop-blur-2xl dark:border-neutral-800 dark:bg-zinc-800/30 dark:from-inherit lg:static lg:w-auto  lg:rounded-xl lg:border lg:bg-gray-200 lg:p-4 lg:dark:bg-zinc-800/30">
           Get started by editing&nbsp;
           <code className="font-mono font-bold">src/app/page.tsx</code>
@@ -15,7 +16,7 @@ export default function Home() {
             target="_blank"
             rel="noopener noreferrer"
           >
-            By{' '}
+            By{" "}
             <Image
               src="/vercel.svg"
               alt="Vercel Logo"
@@ -47,7 +48,7 @@ export default function Home() {
           rel="noopener noreferrer"
         >
           <h2 className={`mb-3 text-2xl font-semibold`}>
-            Docs{' '}
+            Docs{" "}
             <span className="inline-block transition-transform group-hover:translate-x-1 motion-reduce:transform-none">
               -&gt;
             </span>
@@ -64,7 +65,7 @@ export default function Home() {
           rel="noopener noreferrer"
         >
           <h2 className={`mb-3 text-2xl font-semibold`}>
-            Learn{' '}
+            Learn{" "}
             <span className="inline-block transition-transform group-hover:translate-x-1 motion-reduce:transform-none">
               -&gt;
             </span>
@@ -81,7 +82,7 @@ export default function Home() {
           rel="noopener noreferrer"
         >
           <h2 className={`mb-3 text-2xl font-semibold`}>
-            Templates{' '}
+            Templates{" "}
             <span className="inline-block transition-transform group-hover:translate-x-1 motion-reduce:transform-none">
               -&gt;
             </span>
@@ -98,7 +99,7 @@ export default function Home() {
           rel="noopener noreferrer"
         >
           <h2 className={`mb-3 text-2xl font-semibold`}>
-            Deploy{' '}
+            Deploy{" "}
             <span className="inline-block transition-transform group-hover:translate-x-1 motion-reduce:transform-none">
               -&gt;
             </span>
@@ -109,5 +110,5 @@ export default function Home() {
         </a>
       </div>
     </main>
-  )
+  );
 }

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,0 +1,3 @@
+{
+  "buildCommand": "turbo build --filter=ui --filter=web"
+}


### PR DESCRIPTION
## 한 줄 요약
admin, web 에서 PR 작성 및 업데이트시에 프리뷰 생성하는 workflow를 추가합니다. 

## 자세한 내용

- 모노래포를 사용하지만 github action + vercel 을 이용해서 개별적으로 프리뷰를 생성해줍니다.
- vercel bot을 연결해서 프리뷰를 만들 수 있지만, 이런 경우 기본적으로 변경 발생시 바로 재실행이 되며 vercel 서비스 내에서 빌드를 하며 설정 값도 제한적으로 설정이 가능하기에 한계가 있습니다. 
-  좀더 세부적으로 설정가능하도록 github action 영역에서 vercel cli를 이용해서 빌드 및 deploy를 해주고 vercel 쪽에서는 빌드된 결과물을 받아서 프리뷰를 생성해 주는 방식으로 진행했습니다. 
- push 이벤트 트리거로 할 경우 `context.payload.pull_request` 정보가 아예 들어오지 않습니다. 따라서 github-script에서 위의 정보를 사용하기 위해선 pull request 이벤트 트리거를 써야 합니다. 
- secret 변수를 아래와 같이 사용합니다.
```
VERCEL_ORG_ID           : vercel organization id 또는  vercel personal id
VERCEL_WEB_PROJECT_ID   : web vercel project id
VERCEL_ADMIN_PROJECT_ID : admin vercel project id
VERCEL_TOKEN            : vercel access token
ACCESS_TOKEN_PR_COMMENT : github access token 
```